### PR TITLE
Cumulative PR for cg management, error handling and comments

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,10 @@ func run() {
 	errorHandler(cmd.Run())
 	defer errorHandler(cgDestroy())
 
+	// This log message shows exactly when the child process returns to the
+	// parent
+	log.Println("Container exited")
+
 }
 
 // child runs the containerized process in the previuosly isolated namespaces
@@ -106,10 +110,9 @@ func child() {
 	// data
 	log.Println("Mounting container proc filesystem")
 	errorHandler(syscall.Mount("proc", "proc", "proc", 0, ""))
+	defer errorHandler(syscall.Unmount("proc", 0))
 
 	errorHandler(cmd.Run())
-
-	errorHandler(syscall.Unmount("proc", 0))
 
 }
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ These files will be mounted in the container root
 */
 
 const (
+	// TODO: manage the root directory with an environment variable or a flag
 	rootfs            = "/home/gbsalinetti/go/src/github.com/giannisalinetti/goContainerPOC/rootfs/quux" //Change this according to your directory
 	containerHostname = "demo"                                                                           //Container host name, change if you want
 	cgroupsDirectory  = "/sys/fs/cgroup"                                                                 //Host cgroup directory
@@ -57,6 +58,7 @@ func main() {
 	}
 }
 
+// run executed the main same process with the "child" argument
 func run() {
 	log.Printf("Creating child process with kernel namespaces for running %v \n", os.Args[2:])
 
@@ -83,6 +85,7 @@ func run() {
 
 }
 
+// child runs the containerized process in the previuosly isolated namespaces
 func child() {
 	log.Printf("Running %v in containerized child\n", os.Args[2:])
 
@@ -99,6 +102,8 @@ func child() {
 	errorHandler(syscall.Chroot(rootfs))
 	errorHandler(os.Chdir("/"))
 
+	// Mounting the proc filesystem is necessary to access the processes
+	// data
 	log.Println("Mounting container proc filesystem")
 	errorHandler(syscall.Mount("proc", "proc", "proc", 0, ""))
 

--- a/main.go
+++ b/main.go
@@ -110,9 +110,10 @@ func child() {
 	// data
 	log.Println("Mounting container proc filesystem")
 	errorHandler(syscall.Mount("proc", "proc", "proc", 0, ""))
-	defer errorHandler(syscall.Unmount("proc", 0))
 
 	errorHandler(cmd.Run())
+
+	errorHandler(syscall.Unmount("proc", 0))
 
 }
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ if you want to build rootfs use mkosi tool:
 
 -- build on ubuntu 18-04 with:
    sudo mkosi -d ubuntu -t directory -o quux -r xenial
-
 These files are avaible under rootfs/quux if you have some issue with mkosi
 Remeber to fix this path with yours!
 These files will be mounted in the container root
@@ -68,7 +67,14 @@ func run() {
 	cmd.Stderr = os.Stderr
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Cloneflags:   syscall.CLONE_NEWUTS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
+		Cloneflags: syscall.CLONE_NEWUTS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
+		// Setting the Unshareflags to CLONE_NEWNS here is a workaround to hide
+		// the container mounts to the host. This happens since systemd forces
+		// all mount namespaces to be shared. The only workaround was to remount
+		// internally with MS_PRIVATE flag. The workaround was implemented in
+		// Go 1.9 and remounts with MS_REC|MS_PRIVATE when the unshare flag
+		// CLONE_NEWNS is set. For more details see the following thread:
+		// https://go-review.googlesource.com/c/go/+/38471
 		Unshareflags: syscall.CLONE_NEWNS,
 	}
 


### PR DESCRIPTION
This PR tries to improve the error handling by lowering the goroutines execution and fixes an hidden issue with the creation of the /sys/fs/cgroup/pids/<dirname> directory during the demo. This directory was not deleted upon exit.
More verbose comments have been added.